### PR TITLE
naming-convention: added functionVariable type

### DIFF
--- a/docs/naming-convention.md
+++ b/docs/naming-convention.md
@@ -90,6 +90,16 @@ After filtering the formatting rules are reduced from the first to the last. Rem
   * `global` or `local`
   * `export`
 
+#### functionVariable
+
+* Scope: every variable that is initialized with an arrow function or function expression
+* Extends: `variable`
+* Valid modifiers:
+  * `global` or `local`
+  * `const`
+  * `export`
+  * `unused` // if the variable is never used
+
 #### parameter
 
 * Scope: parameters
@@ -199,6 +209,8 @@ Here you see an example of how everything explained above works together. This i
   {"type": "variable", "modifiers": ["global", "const"], "format": ["camelCase","UPPER_CASE"]},
   // override the above format option for exported constants to allow only UPPER_CASE
   {"type": "variable", "modifiers": ["export", "const"], "format": "UPPER_CASE"},
+  // require exported constant variables that are initialized with functions to be camelCase
+  {"type": "functionVariable", "modifiers": ["export", "const"], "format": "camelCase"},
   // allow leading underscores for unused parameters, because `tsc --noUnusedParameters` will not flag underscore prefixed parameters
   // all other rules (trailingUnderscore: forbid, format: camelCase) still apply
   {"type": "parameter", "modifiers": "unused", "leadingUnderscore": "allow"},

--- a/test/rules/naming-convention/default/test.ts.lint
+++ b/test/rules/naming-convention/default/test.ts.lint
@@ -142,3 +142,8 @@ abstract class Foo {
     abstract private _barAjaff();
 }
 abstract class AbstractFoo() {}
+
+// `functionVariable` is not defined in the config, so this should use the `variable` options.
+let fooFunc = () => undefined;
+let foo_func = () => undefined;
+    ~~~~~~~~ [functionVariable name must be in camelCase]

--- a/test/rules/naming-convention/function-variables/test.ts.lint
+++ b/test/rules/naming-convention/function-variables/test.ts.lint
@@ -1,0 +1,49 @@
+// Default - should be snake_case.
+let default_snake  = "";
+let DefaultPascal = "";
+    ~~~~~~~~~~~~~    [variable name must be in snake_case]
+
+
+// Exported variables - should be UPPER_CASE.
+export let EXPORTED_VAR = "";
+export let exportedVar = "";
+           ~~~~~~~~~~~ [variable name must be in UPPER_CASE]
+
+
+// Exported functions - should be camelCase.
+export function funcCamel() {}
+export function FUNC_CAMEL() {}
+                ~~~~~~~~~~ [function name must be in camelCase]
+
+
+// Exported function variables - should be in PascalCase.
+export let FuncArrowVar = () => undefined;
+export let FUNC_ARROW_VAR = () => undefined;
+           ~~~~~~~~~~~~~~ [functionVariable name must be in PascalCase]
+export let FuncExpressionVar = function() {};
+export let FUNC_EXPRESSION_VAR = function() {};
+           ~~~~~~~~~~~~~~~~~~~ [functionVariable name must be in PascalCase]
+
+
+// Const function variables - should be in camelCase.
+const funcArrowVar = () => undefined;
+const FUNC_ARROW_VAR = () => undefined;
+      ~~~~~~~~~~~~~~ [functionVariable name must be in camelCase]
+const funcExpressionVar = function() {};
+const FUNC_EXPRESSION_VAR = function() {};
+      ~~~~~~~~~~~~~~~~~~~ [functionVariable name must be in camelCase]
+
+
+// Named functions - should be in snake_case (the default).
+export let NamedFuncExpressionVar = function named_foo() {};
+export let NAMED_FUNC_EXPRESSION_VAR = function NAMED_FOO() {};
+           ~~~~~~~~~~~~~~~~~~~~~~~~~ [functionVariable name must be in PascalCase]
+                                                ~~~~~~~~~ [function name must be in snake_case]
+
+
+// Local function variables - should be UPPER_CASE.
+function local_test() {
+    let LOCAL_FUNC = () => undefined;
+    let localFunc = () => undefined;
+        ~~~~~~~~~ [functionVariable name must be in UPPER_CASE]
+}

--- a/test/rules/naming-convention/function-variables/tslint.json
+++ b/test/rules/naming-convention/function-variables/tslint.json
@@ -1,0 +1,14 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "naming-convention": [
+      true,
+      { "type": "default", "format": "snake_case" },
+      { "type": "variable", "modifiers": "export", "format": "UPPER_CASE" },
+      { "type": "function", "modifiers": "export", "format": "camelCase" },
+      { "type": "functionVariable", "modifiers": "export", "format": "PascalCase" },
+      { "type": "functionVariable", "modifiers": "local", "format": "UPPER_CASE" },
+      { "type": "functionVariable", "modifiers": "const", "format": "camelCase" }
+    ]
+  }
+}


### PR DESCRIPTION
Added a new `functionVariable` type to the `naming-convention` rule. This is used for variables that are initialized with an arrow function or function expression. It inherits from the `variable` type.

Fixes #41.