### PR TITLE
no-else-after-return: add option 'allow-else-if'

### DIFF
--- a/docs/no-else-after-return.md
+++ b/docs/no-else-after-return.md
@@ -5,3 +5,37 @@ Works like [no-else-return from eslint](http://eslint.org/docs/rules/no-else-ret
 > If an if block contains a return statement, the else block becomes unnecessary. Its contents can be placed outside of the block.
 
 If you like this rule, I recommend you try [`no-unnecessary-else`](./no-unnecessary-else.md) for some bonus features.
+
+### Options
+
+#### `"allow-else-if"`
+
+Example config:
+
+```js
+"no-else-after-return": {
+  "options": "allow-else-if"
+}
+
+// or
+
+"no-else-after-return": [true, "allow-else-if"]
+```
+
+Enable this option if you prefer `else if` blocks after `return` statements:
+
+```js
+if (condition) {
+  return 'foo';
+} else if (otherCondition) { // this is allowed with the option
+  return 'bar';
+}
+
+if (condition) {
+  return 'foo';
+} else if (otherCondition) {
+  return 'bar';
+} else { // this is still not allowed with the option
+  return 'baz';
+}
+```

--- a/rules/noElseAfterReturnRule.ts
+++ b/rules/noElseAfterReturnRule.ts
@@ -3,25 +3,43 @@ import * as Lint from 'tslint';
 
 import { isElseIf } from '../src/utils';
 import { AbstractIfStatementWalker } from '../src/walker';
-import { getControlFlowEnd, isReturnStatement } from 'tsutils';
+import { isIfStatement, getControlFlowEnd, isReturnStatement } from 'tsutils';
 
 const FAIL_MESSAGE = `unnecessary else after return`;
+const OPTION_ALLOW_ELSE_IF = 'allow-else-if';
+
+interface IOptions {
+    allowElseIf: boolean;
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new IfWalker(sourceFile, this.ruleName, undefined));
+        return this.applyWithWalker(new IfWalker(sourceFile, this.ruleName, {
+            allowElseIf: this.ruleArguments.indexOf(OPTION_ALLOW_ELSE_IF) !== -1,
+        }));
     }
 }
 
-class IfWalker extends AbstractIfStatementWalker<void> {
+class IfWalker extends AbstractIfStatementWalker<IOptions> {
     protected _checkIfStatement(node: ts.IfStatement) {
-        if (
-            node.elseStatement !== undefined &&
-            !isElseIf(node) &&
-            endsWithReturnStatement(node.thenStatement)
-        )
+        if (shouldCheckNode(node, this.options.allowElseIf) && endsWithReturnStatement(node.thenStatement))
             this.addFailureAtNode(node.getChildAt(5 /*else*/, this.sourceFile), FAIL_MESSAGE);
     }
+}
+
+function shouldCheckNode(node: ts.IfStatement, allowElseIf: boolean): boolean {
+    if (node.elseStatement === undefined)
+        return false;
+    if (!allowElseIf)
+        return !isElseIf(node);
+    if (isIfStatement(node.elseStatement) && isElseIf(node.elseStatement))
+        return false;
+    while (isElseIf(node)) {
+        node = node.parent;
+        if (!endsWithReturnStatement(node.thenStatement))
+            return false;
+    }
+    return true;
 }
 
 function endsWithReturnStatement(node: ts.Statement): boolean {

--- a/test/rules/no-else-after-return/allow-else-if/test.ts.lint
+++ b/test/rules/no-else-after-return/allow-else-if/test.ts.lint
@@ -1,0 +1,72 @@
+if (condition) {
+    return;
+} else {
+  ~~~~ [fail]
+    return;
+}
+
+if (condition) {
+    return;
+} else if (someOtherCondition) {
+    return;
+}
+
+if (condition) {
+    return;
+} else if (someOtherCondition) {
+    return;
+} else {
+  ~~~~ [fail]
+    return;
+}
+
+if (condition) {
+    return;
+} else if (someOtherCondition) {
+    return;
+} else if (yetAnotherCondition) {
+    return;
+} else {
+  ~~~~ [fail]
+    return;
+}
+
+if (condition) {
+    // nothing
+} else if (someOtherCondition) {
+    return;
+} else {
+    return;
+}
+
+if (condition) {
+    // nothing
+} else if (someOtherCondition) {
+    return;
+} else if (yetAnotherCondition) {
+    return;
+} else {
+    return;
+}
+
+if (condition) {
+    return;
+} else if (someOtherCondition) {
+    // nothing
+} else if (yetAnotherCondition) {
+    return;
+} else {
+    return;
+}
+
+if (condition) {
+    return;
+} else if (someOtherCondition) {
+    return;
+} else if (yetAnotherCondition) {
+    // nothing
+} else {
+    return;
+}
+
+[fail]: unnecessary else after return

--- a/test/rules/no-else-after-return/allow-else-if/tslint.json
+++ b/test/rules/no-else-after-return/allow-else-if/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": "../../../../rules",
+  "rules": {
+    "no-else-after-return": [true, "allow-else-if"]
+  }
+}


### PR DESCRIPTION
Adds a new option `"allow-else-if"` to allow `else if` blocks. ESLint has this enabled by default. I decided to make the rule strict by default and let the user opt out of certain checks if necessary.

Fixes: #43 
