### PR TITLE
naming-convention filter fix

### DIFF
--- a/test/rules/naming-convention/filter/test.ts.lint
+++ b/test/rules/naming-convention/filter/test.ts.lint
@@ -1,0 +1,5 @@
+function foo(baz) {}
+function foo(Baz) {}
+function foo(bar) {}
+function foo(Bar) {}
+             ~~~     [parameter name must be in camelCase]

--- a/test/rules/naming-convention/filter/tslint.json
+++ b/test/rules/naming-convention/filter/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "naming-convention": [
+       true,
+      {"type": "parameter", "format": ["camelCase"]},
+      {"type": "parameter", "format": ["PascalCase"], "filter": "Baz"}
+    ]
+  }
+}


### PR DESCRIPTION
Follow-up to: https://github.com/ajafff/tslint-consistent-codestyle/issues/113