### PR TITLE
Make early-exit consider throwing as an early exit

### DIFF
--- a/rules/earlyExitRule.ts
+++ b/rules/earlyExitRule.ts
@@ -1,4 +1,4 @@
-import { isBlock, isCaseOrDefaultClause, isIfStatement, isFunctionScopeBoundary } from 'tsutils';
+import { isBlock, isThrowStatement, isCaseOrDefaultClause, isIfStatement, isFunctionScopeBoundary } from 'tsutils';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 
@@ -52,7 +52,7 @@ function walk(ctx: Lint.WalkContext<IOptions>) {
         const thenSize = size(thenStatement, sourceFile);
 
         if (elseStatement === undefined) {
-            if (isLarge(thenSize))
+            if (isLarge(thenSize) || !isThrowStatement(thenStatement))
                 fail(failureString(exit));
             return;
         }
@@ -90,6 +90,14 @@ function size(node: ts.Node, sourceFile: ts.SourceFile): number {
     return isBlock(node)
         ? node.statements.length === 0 ? 0 : diff(node.statements[0].getStart(sourceFile), node.statements.end, sourceFile)
         : diff(node.getStart(sourceFile), node.end, sourceFile);
+}
+
+function isThrow(node: ts.Node): boolean {
+    return isBlock(node)
+        ? node.statements.length > 0
+            ? isThrowStatement(node.statements[0])
+            : false
+        : isThrowStatement(node);
 }
 
 function diff(start: number, end: number, sourceFile: ts.SourceFile): number {

--- a/rules/earlyExitRule.ts
+++ b/rules/earlyExitRule.ts
@@ -52,7 +52,7 @@ function walk(ctx: Lint.WalkContext<IOptions>) {
         const thenSize = size(thenStatement, sourceFile);
 
         if (elseStatement === undefined) {
-            if (isLarge(thenSize) || !isThrowStatement(thenStatement))
+            if (isLarge(thenSize) || !isThrow(thenStatement))
                 fail(failureString(exit));
             return;
         }

--- a/rules/earlyExitRule.ts
+++ b/rules/earlyExitRule.ts
@@ -52,7 +52,7 @@ function walk(ctx: Lint.WalkContext<IOptions>) {
         const thenSize = size(thenStatement, sourceFile);
 
         if (elseStatement === undefined) {
-            if (isLarge(thenSize) || !isThrow(thenStatement))
+            if (isLarge(thenSize) && !isThrow(thenStatement))
                 fail(failureString(exit));
             return;
         }
@@ -94,7 +94,7 @@ function size(node: ts.Node, sourceFile: ts.SourceFile): number {
 
 function isThrow(node: ts.Node): boolean {
     return isBlock(node)
-        ? node.statements.length > 0
+        ? node.statements.length === 1
             ? isThrowStatement(node.statements[0])
             : false
         : isThrowStatement(node);

--- a/test/rules/early-exit/throwing-is-early-exit/test.ts.lint
+++ b/test/rules/early-exit/throwing-is-early-exit/test.ts.lint
@@ -1,0 +1,8 @@
+class Foo {
+    f(a) {
+        if (a === undefined) {
+            throw new Error("a is undefined");
+        }
+    }
+}
+

--- a/test/rules/early-exit/throwing-is-early-exit/tslint.json
+++ b/test/rules/early-exit/throwing-is-early-exit/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": "../../../../rules",
+    "rules": {
+        "early-exit": true
+    }
+}


### PR DESCRIPTION
Hi @ajafff 

Thanks for creating this package. I use multiple rules, which I find very useful.

I was considering enabling `early-exit`, but was surprised by tslint complaining about this pattern:

```ts
private _validateSomething(param: T) {
    if (condition(param)) {
      throw new InvalidParam(param);
    }
}
```

I can refactor that into this, but it feels like making things more complex instead of simpler:

```ts
private _validateSomething(param: T) {
    if (!condition(param)) {
      return;
    }

    throw new InvalidParam(param);
}
```

So I modified this rule to consider throwing as an early exit. 

I'm not 100% sure if what I did is correct, nor if the test I added actually works, but I preferred submitting this early to get your opinion about this change.